### PR TITLE
Add support for compressed id64 set in category and models list

### DIFF
--- a/src/models/ITwin3dView.ts
+++ b/src/models/ITwin3dView.ts
@@ -2,8 +2,8 @@ import { Id64Array, Id64String } from "@itwin/core-bentley";
 import { NewClipPrimitivePlaneProps, NewClipPrimitiveShapeProps } from "./ClipVectors";
 
 export interface ViewVisibilityList {
-  enabled?: Id64Array;
-  disabled?: Id64Array;
+  enabled?: Id64Array | string;
+  disabled?: Id64Array | string;
 }
 
 export interface SubCategoryOverrideData {


### PR DESCRIPTION
Saved views started returning categories and models in compressed id64 set from the API. This PR adds support for it.

![image](https://github.com/simsta6/transform-parameter-builder/assets/25615181/cfe38cd5-9cdb-4f31-8883-94d8194bd75e)
